### PR TITLE
Connect game logic

### DIFF
--- a/src/components/Game.js
+++ b/src/components/Game.js
@@ -2,7 +2,7 @@ import React, { useState } from 'react'
 import Row from './Row'
 import { splitEvery } from 'ramda'
 import update from '../game/update'
-const init = require('../game/init')
+import init from '../game/init'
 
 const createRows = (board, onClick) =>
   splitEvery(3, board).map((row, index) => (

--- a/src/components/Game.js
+++ b/src/components/Game.js
@@ -1,28 +1,12 @@
 import React, { useState } from 'react'
 import Row from './Row'
-import { splitEvery } from 'ramda'
 import update from '../game/update'
 import init from '../game/init'
-import { GAME_MODE, UNCLICKABLE_SQUARE, EMPTY_SQUARE } from '../constants'
+import parseMessage from '../utils/parseMessage'
+import parseRows from '../utils/parseRows'
 
-const createRows = (board, onClick) =>
-  splitEvery(3, board).map((row, index) => (
-    <Row key={index} row={index + 1} squares={row} onClick={onClick} />
-  ))
-
-const message = ({ isActive, messages }) =>
-  isActive ? messages.turn : messages.ending
-
-const parseBoard = ({ isActive, board }) =>
-  isActive
-    ? board
-    : board.map(square =>
-        square === EMPTY_SQUARE ? UNCLICKABLE_SQUARE : square
-      )
-
-function Game() {
-  const [game, updateGame] = useState(init(GAME_MODE))
-  const board = parseBoard(game)
+const Game = ({ mode = 'human' }) => {
+  const [game, updateGame] = useState(init(mode))
 
   const onClick = position => {
     updateGame(update(position, game))
@@ -30,9 +14,9 @@ function Game() {
 
   return (
     <div className="App">
-      <div className="board">{createRows(board, onClick)}</div>
+      <div className="board">{parseRows(game, Row, onClick)}</div>
       <div className="message">
-        <h2>{message(game)}</h2>
+        <h2>{parseMessage(game)}</h2>
       </div>
     </div>
   )

--- a/src/components/Game.js
+++ b/src/components/Game.js
@@ -5,7 +5,7 @@ import init from '../game/init'
 import parseMessage from '../utils/parseMessage'
 import parseRows from '../utils/parseRows'
 
-const Game = ({ mode = 'human' }) => {
+const Game = ({ mode }) => {
   const [game, updateGame] = useState(init(mode))
 
   const onClick = position => {

--- a/src/components/Game.js
+++ b/src/components/Game.js
@@ -1,19 +1,33 @@
-import React from 'react'
+import React, { useState } from 'react'
 import Row from './Row'
 import { splitEvery } from 'ramda'
+import update from '../game/update'
+const init = require('../game/init')
 
-const createRows = board =>
+const createRows = (board, onClick) =>
   splitEvery(3, board).map((row, index) => (
-    <Row key={index} row={index + 1} squares={row} onClick={console.log} />
+    <Row key={index} row={index + 1} squares={row} onClick={onClick} />
   ))
 
+const message = ({ isActive, messages }) =>
+  isActive ? messages.turn : messages.ending
+
+const parseBoard = ({ isActive, board }) =>
+  isActive ? board : board.map(square => (square === null ? '' : square))
+
 function Game() {
-  const board = ['X', 'O', 'X', 'O', 'X', 'O', 'X', 'O', null]
+  const [game, updateGame] = useState(init('ai'))
+  const board = parseBoard(game)
+
+  const onClick = position => {
+    updateGame(update(position, game))
+  }
+
   return (
     <div className="App">
-      <div className="board">{createRows(board)}</div>
+      <div className="board">{createRows(board, onClick)}</div>
       <div className="message">
-        <h2>Player X Wins!</h2>
+        <h2>{message(game)}</h2>
       </div>
     </div>
   )

--- a/src/components/Game.js
+++ b/src/components/Game.js
@@ -3,6 +3,7 @@ import Row from './Row'
 import { splitEvery } from 'ramda'
 import update from '../game/update'
 import init from '../game/init'
+import { GAME_MODE, UNCLICKABLE_SQUARE, EMPTY_SQUARE } from '../constants'
 
 const createRows = (board, onClick) =>
   splitEvery(3, board).map((row, index) => (
@@ -13,10 +14,14 @@ const message = ({ isActive, messages }) =>
   isActive ? messages.turn : messages.ending
 
 const parseBoard = ({ isActive, board }) =>
-  isActive ? board : board.map(square => (square === null ? '' : square))
+  isActive
+    ? board
+    : board.map(square =>
+        square === EMPTY_SQUARE ? UNCLICKABLE_SQUARE : square
+      )
 
 function Game() {
-  const [game, updateGame] = useState(init('ai'))
+  const [game, updateGame] = useState(init(GAME_MODE))
   const board = parseBoard(game)
 
   const onClick = position => {

--- a/src/components/Game.test.js
+++ b/src/components/Game.test.js
@@ -1,9 +1,27 @@
 import React from 'react'
-import ReactDOM from 'react-dom'
 import Game from './Game'
+import { render, fireEvent, cleanup } from '@testing-library/react'
+import '@testing-library/jest-dom/extend-expect'
 
-it('renders without crashing', () => {
-  const div = document.createElement('div')
-  ReactDOM.render(<Game />, div)
-  ReactDOM.unmountComponentAtNode(div)
+afterEach(cleanup)
+
+describe('a Game components', () => {
+  describe('in human v human mode', () => {
+    it('can play a complete game where X wins', () => {
+      const { getByText, getByLabelText } = render(<Game mode="human" />)
+      const squareOne = getByLabelText('Square 1')
+      const squareTwo = getByLabelText('Square 2')
+      const squareThree = getByLabelText('Square 3')
+      const squareFour = getByLabelText('Square 4')
+      const squareFive = getByLabelText('Square 5')
+
+      fireEvent.click(squareOne) // X's turn
+      fireEvent.click(squareFour) // O's turn
+      fireEvent.click(squareTwo) // X's turn
+      fireEvent.click(squareFive) // O's turn
+      fireEvent.click(squareThree) // X's turn
+
+      expect(getByText('Player X wins!')).toBeInTheDocument()
+    })
+  })
 })

--- a/src/components/Game.test.js
+++ b/src/components/Game.test.js
@@ -3,25 +3,36 @@ import Game from './Game'
 import { render, fireEvent, cleanup } from '@testing-library/react'
 import '@testing-library/jest-dom/extend-expect'
 
-afterEach(cleanup)
-
-describe('a Game components', () => {
+describe('a Game component', () => {
   describe('in human v human mode', () => {
     it('can play a complete game where X wins', () => {
       const { getByText, getByLabelText } = render(<Game mode="human" />)
-      const squareOne = getByLabelText('Square 1')
-      const squareTwo = getByLabelText('Square 2')
-      const squareThree = getByLabelText('Square 3')
-      const squareFour = getByLabelText('Square 4')
-      const squareFive = getByLabelText('Square 5')
+      const crossMoves = [1, 2, 3]
+      const noughtMoves = [4, 5]
 
-      fireEvent.click(squareOne) // X's turn
-      fireEvent.click(squareFour) // O's turn
-      fireEvent.click(squareTwo) // X's turn
-      fireEvent.click(squareFive) // O's turn
-      fireEvent.click(squareThree) // X's turn
+      combineAlternating(crossMoves, noughtMoves).forEach(move =>
+        fireEvent.click(getByLabelText(`Square ${move}`))
+      )
 
       expect(getByText('Player X wins!')).toBeInTheDocument()
     })
   })
 })
+
+afterEach(cleanup)
+
+const combineAlternating = (current, alternate, combined = []) => {
+  if (current.length === 0) {
+    return combined.concat(alternate)
+  }
+
+  return combineAlternating(
+    alternate,
+    tail(current),
+    combined.concat(head(current))
+  )
+}
+
+const head = array => array.slice(0, 1)
+
+const tail = array => array.slice(1)

--- a/src/components/Game.test.js
+++ b/src/components/Game.test.js
@@ -10,16 +10,40 @@ describe('a Game component', () => {
       const crossMoves = [1, 2, 3]
       const noughtMoves = [4, 5]
 
-      combineAlternating(crossMoves, noughtMoves).forEach(move =>
-        fireEvent.click(getByLabelText(`Square ${move}`))
-      )
+      playGame(crossMoves, noughtMoves, getByLabelText)
 
       expect(getByText('Player X wins!')).toBeInTheDocument()
+    })
+
+    it('can play a complete game where O wins', () => {
+      const { getByText, getByLabelText } = render(<Game mode="human" />)
+      const crossMoves = [1, 2, 4]
+      const noughtMoves = [3, 5, 7]
+
+      playGame(crossMoves, noughtMoves, getByLabelText)
+
+      expect(getByText('Player O wins!')).toBeInTheDocument()
+    })
+
+    it('can play a complete game that ends in a draw', () => {
+      const { getByText, getByLabelText } = render(<Game mode="human" />)
+      const crossMoves = [1, 2, 7, 6, 9]
+      const noughtMoves = [5, 3, 4, 8]
+
+      playGame(crossMoves, noughtMoves, getByLabelText)
+
+      expect(getByText(/It's a draw!/)).toBeInTheDocument()
     })
   })
 })
 
 afterEach(cleanup)
+
+const playGame = (crossMoves, noughtMoves, query) => {
+  combineAlternating(crossMoves, noughtMoves).forEach(move =>
+    fireEvent.click(query(`Square ${move}`))
+  )
+}
 
 const combineAlternating = (current, alternate, combined = []) => {
   if (current.length === 0) {

--- a/src/components/Row.js
+++ b/src/components/Row.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import Square from './Square'
 
-const Row = ({ squares, row = 1, onClick }) => (
+const Row = ({ squares, row, onClick }) => (
   <div className="row">{generateRowSquares(squares, row, onClick)}</div>
 )
 

--- a/src/components/Row.js
+++ b/src/components/Row.js
@@ -1,23 +1,35 @@
 import React from 'react'
 import Square from './Square'
 
-const Row = ({ squares, row, onClick }) => (
-  <div className="row">{generateRowSquares(squares, row, onClick)}</div>
+const Row = ({ squares, zeroIndexedRowNumber, onClick }) => (
+  <div className="row">
+    {generateRowSquares(squares, zeroIndexedRowNumber, onClick)}
+  </div>
 )
 
-const generateRowSquares = (squares, row, onClick) =>
-  squares.map((square, index) => (
+const generateRowSquares = (squares, zeroIndexedRowNumber, onClick) => {
+  const numberOfSquaresInRow = squares.length
+  return squares.map((square, index) => (
     <Square
       key={index}
       onClick={onClick}
-      position={calculatePosition(row, index)}
+      zeroIndexedPosition={calculatePosition(
+        index,
+        zeroIndexedRowNumber,
+        numberOfSquaresInRow
+      )}
       value={square}
     />
   ))
+}
 
-const calculatePosition = (row, index) => {
-  const multiplier = (row - 1) * 3
-  return multiplier + index + 1
+const calculatePosition = (
+  index,
+  zeroIndexedRowNumber,
+  numberOfSquaresInRow
+) => {
+  const multiplier = zeroIndexedRowNumber * numberOfSquaresInRow
+  return multiplier + index
 }
 
 export default Row

--- a/src/components/Row.test.js
+++ b/src/components/Row.test.js
@@ -12,7 +12,9 @@ describe('the Row component', () => {
 
     beforeEach(() => {
       const row = [null, null, null]
-      const rendered = render(<Row squares={row} row={1} onClick={onClick} />)
+      const rendered = render(
+        <Row squares={row} zeroIndexedRowNumber={0} onClick={onClick} />
+      )
       getByLabelText = rendered.getByLabelText
     })
 
@@ -39,7 +41,9 @@ describe('the Row component', () => {
 
     beforeEach(() => {
       const row = ['X', 'O', 'X']
-      const rendered = render(<Row squares={row} row={2} onClick={onClick} />)
+      const rendered = render(
+        <Row squares={row} zeroIndexedRowNumber={1} onClick={onClick} />
+      )
       getByLabelText = rendered.getByLabelText
     })
 

--- a/src/components/Row.test.js
+++ b/src/components/Row.test.js
@@ -3,64 +3,72 @@ import Row from './Row'
 import { render, cleanup } from '@testing-library/react'
 import '@testing-library/jest-dom/extend-expect'
 
-afterEach(cleanup)
-
 describe('the Row component', () => {
   describe('will render an empty first row', () => {
-    const onClick = jest.fn()
     let getByLabelText
 
     beforeEach(() => {
       const row = [null, null, null]
       const rendered = render(
-        <Row squares={row} zeroIndexedRowNumber={0} onClick={onClick} />
+        <Row squares={row} zeroIndexedRowNumber={0} onClick={null} />
       )
       getByLabelText = rendered.getByLabelText
     })
 
     it('renders the first square of an empty row', () => {
       const firstSquare = getByLabelText('Square 1')
+
       expect(firstSquare).toBeInTheDocument()
       expect(firstSquare).toBeEmpty()
     })
+
     it('renders the second square of an empty row', () => {
       const secondSquare = getByLabelText('Square 2')
+
       expect(secondSquare).toBeInTheDocument()
       expect(secondSquare).toBeEmpty()
     })
+
     it('renders the third square of an empty row', () => {
       const thirdSquare = getByLabelText('Square 3')
+
       expect(thirdSquare).toBeInTheDocument()
       expect(thirdSquare).toBeEmpty()
     })
   })
 
   describe('will render an occupied second row', () => {
-    const onClick = jest.fn()
     let getByLabelText
 
     beforeEach(() => {
       const row = ['X', 'O', 'X']
       const rendered = render(
-        <Row squares={row} zeroIndexedRowNumber={1} onClick={onClick} />
+        <Row squares={row} zeroIndexedRowNumber={1} onClick={null} />
       )
       getByLabelText = rendered.getByLabelText
     })
 
     it('renders the first square of an occupied row', () => {
       const firstSquare = getByLabelText('Square 4')
+
       expect(firstSquare).toBeInTheDocument()
       expect(firstSquare).toHaveTextContent('X')
     })
+
     it('renders the second square of an occupied row', () => {
       const secondSquare = getByLabelText('Square 5')
+
       expect(secondSquare).toBeInTheDocument()
       expect(secondSquare).toHaveTextContent('O')
     })
+
     it('renders the third square of an occupied row', () => {
       const thirdSquare = getByLabelText('Square 6')
+
       expect(thirdSquare).toBeInTheDocument()
       expect(thirdSquare).toHaveTextContent('X')
     })
   })
 })
+
+afterEach(cleanup)

--- a/src/components/Square.js
+++ b/src/components/Square.js
@@ -1,20 +1,25 @@
 import React from 'react'
 import { EMPTY_SQUARE, PLAYER_CROSS_MARK } from '../constants'
 
-const Square = ({ position, value, onClick }) => (
-  <button
-    onClick={value !== EMPTY_SQUARE ? null : () => onClick(position)}
-    aria-label={`Square ${position}`}
-    className={
-      value === null
-        ? 'square available'
-        : value === PLAYER_CROSS_MARK
-        ? 'square player-one'
-        : 'square player-two'
-    }
-  >
-    {value}
-  </button>
-)
+const Square = ({ zeroIndexedPosition, value, onClick }) => {
+  const position = numberToOneIndex(zeroIndexedPosition)
+  return (
+    <button
+      onClick={value !== EMPTY_SQUARE ? null : () => onClick(position)}
+      aria-label={`Square ${position}`}
+      className={
+        value === null
+          ? 'square available'
+          : value === PLAYER_CROSS_MARK
+          ? 'square player-one'
+          : 'square player-two'
+      }
+    >
+      {value}
+    </button>
+  )
+}
+
+const numberToOneIndex = x => x + 1
 
 export default Square

--- a/src/components/Square.js
+++ b/src/components/Square.js
@@ -1,24 +1,26 @@
 import React from 'react'
-import { EMPTY_SQUARE, PLAYER_CROSS_MARK } from '../constants'
+import { EMPTY_SQUARE } from '../constants'
 
 const Square = ({ zeroIndexedPosition, value, onClick }) => {
   const position = numberToOneIndex(zeroIndexedPosition)
   return (
     <button
-      onClick={value !== EMPTY_SQUARE ? null : () => onClick(position)}
+      onClick={getOnClick(value, onClick, position)}
       aria-label={`Square ${position}`}
-      className={
-        value === null
-          ? 'square available'
-          : value === PLAYER_CROSS_MARK
-          ? 'square player-one'
-          : 'square player-two'
-      }
+      className={getClassName(value)}
     >
       {value}
     </button>
   )
 }
+
+const getOnClick = (value, onClick, position) =>
+  isSquareEmpty(value) ? () => onClick(position) : null
+
+const getClassName = value =>
+  isSquareEmpty(value) ? 'square available' : `square player-${value}`
+
+const isSquareEmpty = value => value === EMPTY_SQUARE
 
 const numberToOneIndex = x => x + 1
 

--- a/src/components/Square.js
+++ b/src/components/Square.js
@@ -2,7 +2,7 @@ import React from 'react'
 
 const Square = ({ position, value, onClick }) => (
   <button
-    onClick={value ? null : () => onClick(position)}
+    onClick={value !== null ? null : () => onClick(position)}
     aria-label={`Square ${position}`}
     className={
       value === null

--- a/src/components/Square.js
+++ b/src/components/Square.js
@@ -1,13 +1,14 @@
 import React from 'react'
+import { EMPTY_SQUARE, PLAYER_CROSS_MARK } from '../constants'
 
 const Square = ({ position, value, onClick }) => (
   <button
-    onClick={value !== null ? null : () => onClick(position)}
+    onClick={value !== EMPTY_SQUARE ? null : () => onClick(position)}
     aria-label={`Square ${position}`}
     className={
       value === null
         ? 'square available'
-        : value === 'X'
+        : value === PLAYER_CROSS_MARK
         ? 'square player-one'
         : 'square player-two'
     }

--- a/src/components/Square.test.js
+++ b/src/components/Square.test.js
@@ -7,7 +7,7 @@ afterEach(cleanup)
 
 describe('the Square component', () => {
   it('can render an empty square', () => {
-    const { getByLabelText } = render(<Square position={1} value="" />)
+    const { getByLabelText } = render(<Square position={1} value={null} />)
 
     const square = getByLabelText('Square 1')
     expect(square).toBeEmpty()
@@ -16,7 +16,7 @@ describe('the Square component', () => {
   it('will let you click on an empty square', () => {
     const onClick = jest.fn()
     const { getByLabelText } = render(
-      <Square position={5} value="" onClick={onClick} />
+      <Square position={5} value={null} onClick={onClick} />
     )
     const square = getByLabelText('Square 5')
     const position = 5

--- a/src/components/Square.test.js
+++ b/src/components/Square.test.js
@@ -7,7 +7,9 @@ afterEach(cleanup)
 
 describe('the Square component', () => {
   it('can render an empty square', () => {
-    const { getByLabelText } = render(<Square position={1} value={null} />)
+    const { getByLabelText } = render(
+      <Square zeroIndexedPosition={0} value={null} />
+    )
 
     const square = getByLabelText('Square 1')
     expect(square).toBeEmpty()
@@ -16,7 +18,7 @@ describe('the Square component', () => {
   it('will let you click on an empty square', () => {
     const onClick = jest.fn()
     const { getByLabelText } = render(
-      <Square position={5} value={null} onClick={onClick} />
+      <Square zeroIndexedPosition={4} value={null} onClick={onClick} />
     )
     const square = getByLabelText('Square 5')
     const position = 5
@@ -28,7 +30,9 @@ describe('the Square component', () => {
   })
 
   it('can be rendered with a cross', () => {
-    const { getByLabelText } = render(<Square position={1} value="X" />)
+    const { getByLabelText } = render(
+      <Square zeroIndexedPosition={0} value="X" />
+    )
 
     const square = getByLabelText('Square 1')
 
@@ -38,7 +42,7 @@ describe('the Square component', () => {
   it('will not let you click on an occupied square', () => {
     const onClick = jest.fn()
     const { getByLabelText } = render(
-      <Square position={1} value="X" onClick={onClick} />
+      <Square zeroIndexedPosition={0} value="X" onClick={onClick} />
     )
     const square = getByLabelText('Square 1')
 

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,0 +1,5 @@
+export const PLAYER_CROSS_MARK = 'X'
+export const PLAYER_NOUGHT_MARK = 'O'
+export const EMPTY_SQUARE = null
+export const UNCLICKABLE_SQUARE = ''
+export const GAME_MODE = 'ai'

--- a/src/constants.js
+++ b/src/constants.js
@@ -3,3 +3,4 @@ export const PLAYER_NOUGHT_MARK = 'O'
 export const EMPTY_SQUARE = null
 export const UNCLICKABLE_SQUARE = ''
 export const GAME_MODE = 'ai'
+export const BOARD_SIZE = 9

--- a/src/game/ai/minimax.js
+++ b/src/game/ai/minimax.js
@@ -1,15 +1,15 @@
-const referee = require('../referee')
-const {
+import referee from '../referee'
+import {
   bestPositionReducer,
   maximumReducer,
   minimumReducer,
-} = require('./minimaxReducers')
+} from './minimaxReducers'
 
 const WINNING_SCORE = 10
 const LOSING_SCORE = -10
 const DRAW_SCORE = 0
 
-const initialise = (board, maximisingPlayer) => {
+const minimax = (board, maximisingPlayer) => {
   if (referee.available(board).length === 0) {
     throw new TypeError('Must supply a board board that is not full')
   }
@@ -68,4 +68,4 @@ const calculatePlayers = maximisingPlayer => ({
   minimiser: maximisingPlayer === 'X' ? 'O' : 'X',
 })
 
-module.exports = initialise
+export default minimax

--- a/src/game/ai/minimax.js
+++ b/src/game/ai/minimax.js
@@ -10,8 +10,8 @@ const LOSING_SCORE = -10
 const DRAW_SCORE = 0
 
 const minimax = (board, maximisingPlayer) => {
-  if (referee.available(board).length === 0) {
-    throw new TypeError('Must supply a board board that is not full')
+  if (referee.boardIsFull(board)) {
+    throw new TypeError('Must supply a board that is not full')
   }
 
   const players = calculatePlayers(maximisingPlayer)
@@ -27,10 +27,10 @@ const minimax = (board, maximisingPlayer) => {
 
 const scoreMax = (board, players) => {
   if (referee.hasWinner(board)) {
-    return WINNING_SCORE + referee.available(board).length
+    return WINNING_SCORE + getWeighting(board)
   }
 
-  if (referee.available(board).length === 0) {
+  if (referee.boardIsFull(board)) {
     return DRAW_SCORE
   }
 
@@ -46,10 +46,10 @@ const scoreMax = (board, players) => {
 
 const scoreMin = (board, players) => {
   if (referee.hasWinner(board)) {
-    return LOSING_SCORE - referee.available(board).length
+    return LOSING_SCORE - getWeighting(board)
   }
 
-  if (referee.available(board).length === 0) {
+  if (referee.boardIsFull(board)) {
     return DRAW_SCORE
   }
 
@@ -62,6 +62,8 @@ const scoreMin = (board, players) => {
 
   return scores
 }
+
+const getWeighting = board => referee.available(board).length
 
 const calculatePlayers = maximisingPlayer => ({
   maximiser: maximisingPlayer === 'X' ? 'X' : 'O',

--- a/src/game/ai/minimax.test.js
+++ b/src/game/ai/minimax.test.js
@@ -1,5 +1,5 @@
-const minimax = require('./minimax')
-const referee = require('../referee')
+import minimax from './minimax'
+import referee from '../referee'
 
 describe('the minimax algorithm', () => {
   let board

--- a/src/game/ai/minimaxPlayer.js
+++ b/src/game/ai/minimaxPlayer.js
@@ -1,7 +1,5 @@
-const minimax = require('./minimax')
+import minimax from './minimax'
 
-module.exports = {
-  chooseMove: (board, state) => {
-    return minimax(state, 'O').position
-  },
+export default {
+  chooseMove: (board, state) => minimax(state, 'O').position,
 }

--- a/src/game/ai/minimaxReducers.js
+++ b/src/game/ai/minimaxReducers.js
@@ -9,4 +9,4 @@ const minimumReducer = (acc, x) => (x < acc ? x : acc)
 
 const maximumReducer = (acc, x) => (x > acc ? x : acc)
 
-module.exports = { bestPositionReducer, minimumReducer, maximumReducer }
+export { bestPositionReducer, minimumReducer, maximumReducer }

--- a/src/game/board.test.js
+++ b/src/game/board.test.js
@@ -1,4 +1,4 @@
-const referee = require('./referee')
+import referee from './referee'
 
 describe('The referee object', () => {
   describe('With referee.create()', () => {

--- a/src/game/index.js
+++ b/src/game/index.js
@@ -1,8 +1,8 @@
-const init = require('./init')
-const update = require('./update')
-const validator = require('./validator')
+import init from './init'
+import update from './update'
+import validator from './validator'
 
-module.exports = {
+export default {
   init,
   update,
   validator,

--- a/src/game/init.js
+++ b/src/game/init.js
@@ -1,7 +1,7 @@
-const messages = require('./messages')
-const referee = require('./referee')
+import messages from './messages'
+import referee from './referee'
 
-module.exports = (mode = 'human') => ({
+export default (mode = 'human') => ({
   isActive: true,
   board: referee.create(),
   messages: {

--- a/src/game/init.test.js
+++ b/src/game/init.test.js
@@ -1,4 +1,4 @@
-const init = require('./init')
+import init from './init'
 
 describe('the game initialiser', () => {
   const newGame = init()

--- a/src/game/messages.js
+++ b/src/game/messages.js
@@ -11,5 +11,5 @@ export default {
   draw: "How unsatisfying! It's a draw!",
   unknownError: "Well, something's gone wrong somewhere.",
   winner: mark => `Player ${mark} wins!`,
-  turn: mark => `Player ${mark}'s turn: `,
+  turn: mark => `Player ${mark}'s turn`,
 }

--- a/src/game/messages.js
+++ b/src/game/messages.js
@@ -1,4 +1,4 @@
-module.exports = {
+export default {
   title: 'TIC TAC TOE',
   intro:
     'Win untold glory by successfully placing a complete line in any horizontal, vertical or diagonal direction.',

--- a/src/game/messages.test.js
+++ b/src/game/messages.test.js
@@ -1,4 +1,4 @@
-const messages = require('./messages')
+import messages from './messages'
 
 describe('A messages object', () => {
   it('should have a title', () => {

--- a/src/game/referee.js
+++ b/src/game/referee.js
@@ -54,6 +54,8 @@ const available = board => {
   )
 }
 
+const boardIsFull = board => available(board).length === 0
+
 const withinBounds = (number, board) => number > 0 && number <= board.length
 
 export default {
@@ -63,4 +65,5 @@ export default {
   hasWinner,
   withinBounds,
   available,
+  boardIsFull,
 }

--- a/src/game/referee.js
+++ b/src/game/referee.js
@@ -56,7 +56,7 @@ const available = board => {
 
 const withinBounds = (number, board) => number > 0 && number <= board.length
 
-module.exports = {
+export default {
   create,
   get,
   update,

--- a/src/game/update.js
+++ b/src/game/update.js
@@ -57,4 +57,4 @@ const gameOver = (board, currentPlayer) => ({
   },
 })
 
-module.exports = update
+export default update

--- a/src/game/update.js
+++ b/src/game/update.js
@@ -1,6 +1,6 @@
-const referee = require('./referee')
-const messages = require('./messages')
-const minimax = require('./ai/minimaxPlayer')
+import referee from './referee'
+import messages from './messages'
+import minimax from './ai/minimaxPlayer'
 
 const swapPlayer = currentPlayer => (currentPlayer === 'X' ? 'O' : 'X')
 

--- a/src/game/update.js
+++ b/src/game/update.js
@@ -34,7 +34,7 @@ const update = (position, options) => {
 }
 
 const gameIsOver = board =>
-  referee.hasWinner(board) || referee.available(board).length <= 0
+  referee.hasWinner(board) || referee.boardIsFull(board)
 
 const nextMove = (board, options) => {
   const nextPlayer = swapPlayer(options.currentPlayer)

--- a/src/game/update.test.js
+++ b/src/game/update.test.js
@@ -1,6 +1,6 @@
-const update = require('./update')
-const referee = require('./referee')
-const game = require('./index')
+import update from './update'
+import referee from './referee'
+import game from './index'
 
 describe('the update function', () => {
   it('updates the board', () => {

--- a/src/game/validator.js
+++ b/src/game/validator.js
@@ -1,7 +1,7 @@
-const referee = require('./referee')
-const messages = require('./messages')
+import referee from './referee'
+import messages from './messages'
 
-module.exports = (input, board) => {
+export default (input, board) => {
   const base = 10
   const parsedInput = Number.parseInt(input, base)
 

--- a/src/game/validator.test.js
+++ b/src/game/validator.test.js
@@ -1,5 +1,5 @@
-const validator = require('./validator')
-const referee = require('./referee')
+import validator from './validator'
+import referee from './referee'
 
 describe('the validator function', () => {
   let board

--- a/src/global.css
+++ b/src/global.css
@@ -71,11 +71,11 @@ a {
     cursor: pointer;
 }
 
-.player-one {
+.player-X {
     color: var(--player-one)
 }
 
-.player-two {
+.player-O {
     color: var(--player-two)
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -2,5 +2,6 @@ import React from 'react'
 import ReactDOM from 'react-dom'
 import './global.css'
 import Game from './components/Game'
+import { GAME_MODE } from './constants'
 
-ReactDOM.render(<Game />, document.getElementById('root'))
+ReactDOM.render(<Game mode={GAME_MODE} />, document.getElementById('root'))

--- a/src/utils/parseMessage.js
+++ b/src/utils/parseMessage.js
@@ -1,0 +1,2 @@
+export default ({ isActive, messages }) =>
+  isActive ? messages.turn : messages.ending

--- a/src/utils/parseRows.js
+++ b/src/utils/parseRows.js
@@ -2,8 +2,6 @@ import React from 'react'
 import { splitEvery } from 'ramda'
 import { BOARD_SIZE, EMPTY_SQUARE, UNCLICKABLE_SQUARE } from '../constants'
 
-const zeroToOneIndex = number => number + 1
-
 const isBoardClickable = ({ isActive, board }) =>
   isActive
     ? board
@@ -18,7 +16,7 @@ export default (game, RowComponent, onClick) => {
   return splitEvery(rowSize, board).map((currentRow, index) => (
     <RowComponent
       key={index}
-      row={zeroToOneIndex(index)}
+      zeroIndexedRowNumber={index}
       squares={currentRow}
       onClick={onClick}
     />

--- a/src/utils/parseRows.js
+++ b/src/utils/parseRows.js
@@ -1,0 +1,26 @@
+import React from 'react'
+import { splitEvery } from 'ramda'
+import { BOARD_SIZE, EMPTY_SQUARE, UNCLICKABLE_SQUARE } from '../constants'
+
+const zeroToOneIndex = number => number + 1
+
+const isBoardClickable = ({ isActive, board }) =>
+  isActive
+    ? board
+    : board.map(square =>
+        square === EMPTY_SQUARE ? UNCLICKABLE_SQUARE : square
+      )
+
+export default (game, RowComponent, onClick) => {
+  const rowSize = Math.sqrt(BOARD_SIZE)
+  const board = isBoardClickable(game)
+
+  return splitEvery(rowSize, board).map((currentRow, index) => (
+    <RowComponent
+      key={index}
+      row={zeroToOneIndex(index)}
+      squares={currentRow}
+      onClick={onClick}
+    />
+  ))
+}


### PR DESCRIPTION
This PR connects the game logic to the game itself. Currently one mode is hardcoded in - minimax. 

The 'game' object now sits within a `useState` hook and is updated with an `onClick` function being passed down the child components. Certain utility functions have been squirrelled away in a `utils` directory and used as necessary, chiefly working out what message to display and how to chop up the 1D array into three (or more - if we build to 4X4) separate rows. 

The `messages` object has had to be tweaked slightly because the output with a colon looks great on a CLI app but totally weird in a React app. 

The CommonJS modules have had to be changed to ESModules, because they did not seem to be interoperable with one another (at least not with a default Create React App). 

