### PR TITLE
refactor cypress tests to better arrange, act and assert

### DIFF
--- a/cypress/fixtures/example.json
+++ b/cypress/fixtures/example.json
@@ -1,0 +1,5 @@
+{
+  "name": "Using fixtures to represent data",
+  "email": "hello@cypress.io",
+  "body": "Fixtures are a great way to mock data for responses to routes"
+}

--- a/cypress/integration/minimaxGame.js
+++ b/cypress/integration/minimaxGame.js
@@ -1,49 +1,41 @@
-describe('The app can draw a game', () => {
-  it('successfully loads', () => {
+describe('when playing a human v minimax game', () => {
+  it('starts a game by displaying a message for player X to make a turn', () => {
     cy.visit('/')
-  })
-
-  it('starts with a turn for the cross player', () => {
     cy.contains("Player X's turn")
   })
 
-  it('will let the player play against a minimax opponent for a draw', () => {
-    cy.get(selectSquare(1)).click()
-    cy.get(selectSquare(4)).click()
-    cy.get(selectSquare(3)).click()
-    cy.get(selectSquare(8)).click()
-    cy.get(selectSquare(9)).click()
-  })
+  it('can successfully draw against a minimax opponent', () => {
+    cy.visit('/')
 
-  it('will display a draw message', () => {
+    const playerCrossMoves = [1, 4, 3, 8, 9]
+    playGame(playerCrossMoves)
+
     cy.contains(/It's a draw!/)
   })
-})
 
-describe('The app can lose a game', () => {
-  it('successfully loads', () => {
+  it('can successfully lose to a minimax opponent', () => {
     cy.visit('/')
-  })
 
-  it('starts with a turn for the cross player', () => {
-    cy.contains("Player X's turn")
-  })
+    const playerCrossMoves = [1, 4, 2]
+    playGame(playerCrossMoves)
 
-  it('will let the player play against a minimax opponent for a draw', () => {
-    cy.get(selectSquare(1)).click()
-    cy.get(selectSquare(4)).click()
-    cy.get(selectSquare(2)).click()
-  })
-
-  it('will display a message saying player nought has won', () => {
     cy.contains(/O wins!/)
   })
 
-  it('will not let the player click on any squares after the game is over', () => {
+  it('will not do anything when players click an unoccupied square after the game is over', () => {
+    cy.visit('/')
+
+    const playerCrossMoves = [1, 4, 2]
+    playGame(playerCrossMoves)
+
     cy.get(selectSquare(9))
       .click()
       .should('be.empty')
   })
 })
+
+const playGame = moves => {
+  moves.forEach(move => cy.get(selectSquare(move)).click())
+}
 
 const selectSquare = number => `button[aria-label="Square ${number}"`


### PR DESCRIPTION
cleans up the cypress tests, because getting started guides should never feature a 'do not do this' section. 